### PR TITLE
add: customer receivables card and invoice history modal

### DIFF
--- a/frontend/src/components/invoice-history-modal.tsx
+++ b/frontend/src/components/invoice-history-modal.tsx
@@ -1,0 +1,24 @@
+import { XIcon } from "@/icons";
+import { Dispatch, SetStateAction } from "react";
+
+interface InvoiceHistoryModalProps {
+    setIsInvoiceHistoryModalOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export const InvoiceHistoryModal = ({
+    setIsInvoiceHistoryModalOpen,
+}: InvoiceHistoryModalProps) => {
+    const handleClose = () => setIsInvoiceHistoryModalOpen(false);
+
+    return (
+        <div className="absolute bg-black/40 w-full h-full top-0 left-0 flex justify-center items-center z-50">
+            <div className="w-[480px] max-h-[560px] bg-white px-8 py-6 rounded-lg border shadow-lg relative">
+                <div className="absolute top-4 right-4 cursor-pointer hover:bg-gray-100 p-2 rounded-lg" onClick={handleClose}>
+                    <XIcon />
+                </div>
+                <h1 className="text-2xl font-bold">Invoice History</h1>
+                <p className="text-sm text-gray-500 mt-1">No invoice details available.</p>
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/selected-user.tsx
+++ b/frontend/src/components/selected-user.tsx
@@ -11,6 +11,7 @@ import { UserClientModel } from "../models/user-client.model";
 import { useState } from "react";
 import { Box, Calendar } from "lucide-react";
 import { RestocksModal } from "./restocks-modal";
+import { InvoiceHistoryModal } from "./invoice-history-modal";
 import { SupplierDataModel } from "@/features/suppliers/get-all-suppliers.model";
 
 type UserType = "customer" | "supplier" | "employee";
@@ -25,6 +26,9 @@ export const SelectedUser = ({
   handleEdit,
   ...user
 }: SelectedUserProps & { handleEdit: () => void }) => {
+  const [isInvoiceHistoryModalOpen, setIsInvoiceHistoryModalOpen] = useState(false);
+  const amountInReceivables = 5000; // scaffold placeholder
+
   return (
     <div className="flex flex-col p-5 w-full gap-2">
       <div className="flex items-center justify-between">
@@ -52,6 +56,29 @@ export const SelectedUser = ({
       </div>
 
       <Separator />
+
+      {/* amount in receivables SECTION */}
+      <div
+        className="p-2 rounded-lg bg-wash-gray hover:cursor-pointer hover:shadow-md transition-shadow"
+        onClick={() => setIsInvoiceHistoryModalOpen(true)}
+      >
+        <div className=" flex items-center gap-3">
+          <div className="bg-green-200 h-10 w-10 rounded-lg flex items-center justify-center text-blouse-gray">
+            <span className="text-green-500 font-bold">₱</span>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col justify-center gap-1 ">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold info-name flex gap-2">
+                ₱{amountInReceivables.toLocaleString()}
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <p className="info-id text-sm">Amount in Receivables</p>
+              <RightUpArrowIcon width={18} height={18} className="text-vesper-gray" />
+            </div>
+          </div>
+        </div>
+      </div>
 
       {/* user FULLNAME SECTION */}
       <div className="p-2 rounded-lg bg-wash-gray">
@@ -128,6 +155,10 @@ export const SelectedUser = ({
           </div>
         </div>
       </div>
+
+      {isInvoiceHistoryModalOpen && (
+        <InvoiceHistoryModal setIsInvoiceHistoryModalOpen={setIsInvoiceHistoryModalOpen} />
+      )}
 
       {/* USER ACTIONS SECTION */}
       {type === "supplier" && <SupplierActions />}

--- a/frontend/src/pages/admin/customers/_components/forms/add-customer.form.tsx
+++ b/frontend/src/pages/admin/customers/_components/forms/add-customer.form.tsx
@@ -116,39 +116,37 @@ export const AddCustomerForm = ({ onSuccess }: AddCustomerFormProps) => {
           </div>
         </div>
 
-        {/* REPRESENTATIVE SECTION HEADER */}
-        <div className="pt-2">
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label className="block text-sm font-medium text-gray-700">
             Representative
           </label>
-        </div>
+          <div className="flex w-full justify-between gap-4">
+            <div className="flex flex-col w-full">
+              <input
+                id="firstName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="First Name"
+                {...register("firstName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.firstName?.message}
+              </span>
+            </div>
 
-        {/* FIRST NAME AND LAST NAME */}
-        <div className="flex w-full justify-between gap-4">
-          <div className="flex flex-col w-full">
-            <input
-              id="firstName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="First Name"
-              {...register("firstName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.firstName?.message}
-            </span>
-          </div>
-
-          <div className="flex flex-col w-full">
-            <input
-              id="lastName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="Last Name"
-              {...register("lastName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.lastName?.message}
-            </span>
+            <div className="flex flex-col w-full">
+              <input
+                id="lastName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="Last Name"
+                {...register("lastName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.lastName?.message}
+              </span>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/admin/customers/_components/forms/edit.customer.form.tsx
+++ b/frontend/src/pages/admin/customers/_components/forms/edit.customer.form.tsx
@@ -128,39 +128,37 @@ export const EditCustomerForm = ({
           </div>
         </div>
 
-        {/* REPRESENTATIVE SECTION HEADER */}
-        <div className="pt-2">
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label className="block text-sm font-medium text-gray-700">
             Representative
           </label>
-        </div>
+          <div className="flex w-full justify-between gap-4">
+            <div className="flex flex-col w-full">
+              <input
+                id="firstName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="First Name"
+                {...register("firstName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.firstName?.message}
+              </span>
+            </div>
 
-        {/* FIRST NAME AND LAST NAME */}
-        <div className="flex w-full justify-between gap-4">
-          <div className="flex flex-col w-full">
-            <input
-              id="firstName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="First Name"
-              {...register("firstName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.firstName?.message}
-            </span>
-          </div>
-
-          <div className="flex flex-col w-full">
-            <input
-              id="lastName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="Last Name"
-              {...register("lastName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.lastName?.message}
-            </span>
+            <div className="flex flex-col w-full">
+              <input
+                id="lastName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="Last Name"
+                {...register("lastName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.lastName?.message}
+              </span>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/admin/suppliers/_components/forms/add-supplier.form.tsx
+++ b/frontend/src/pages/admin/suppliers/_components/forms/add-supplier.form.tsx
@@ -90,9 +90,8 @@ export const AddSupplierForm = ({
           </span>
         </div>
 
-        {/* SUPPLIER NAME */}
-        <div className="flex flex-col w-full justify-between gap-2">
-          {/* FIRST NAME */}
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label htmlFor="firstName" className="block text-sm font-medium">
             Representative
           </label>

--- a/frontend/src/pages/admin/suppliers/_components/forms/edit-supplier.form.tsx
+++ b/frontend/src/pages/admin/suppliers/_components/forms/edit-supplier.form.tsx
@@ -104,8 +104,8 @@ export const EditSupplierForm = ({
           />
         </div>
 
-        {/* SUPPLIER NAME */}
-        <div className="flex flex-col w-full justify-between gap-2">
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label htmlFor="firstName" className="block text-sm font-medium">
             Representative
           </label>


### PR DESCRIPTION
- add `Amount in Receivables` section to `components/selected-user.tsx`
- use placeholder value `₱5000` to mirror supplier purchase price style
- click opens UI-only InvoiceHistoryModal (`components/invoice-history-modal.tsx`)
- modal has only title + close, no data fetch/API/back-end behavior
- no backend changes included
<img width="555" height="473" alt="image" src="https://github.com/user-attachments/assets/1ba65142-ae5d-4fdb-a6aa-d9f82e89af99" />


