### PR TITLE
Fix purchase order print/PDF currency formatting and table overflow

### DIFF
--- a/frontend/src/components/invoice-history-modal.tsx
+++ b/frontend/src/components/invoice-history-modal.tsx
@@ -1,0 +1,24 @@
+import { XIcon } from "@/icons";
+import { Dispatch, SetStateAction } from "react";
+
+interface InvoiceHistoryModalProps {
+    setIsInvoiceHistoryModalOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export const InvoiceHistoryModal = ({
+    setIsInvoiceHistoryModalOpen,
+}: InvoiceHistoryModalProps) => {
+    const handleClose = () => setIsInvoiceHistoryModalOpen(false);
+
+    return (
+        <div className="absolute bg-black/40 w-full h-full top-0 left-0 flex justify-center items-center z-50">
+            <div className="w-[480px] max-h-[560px] bg-white px-8 py-6 rounded-lg border shadow-lg relative">
+                <div className="absolute top-4 right-4 cursor-pointer hover:bg-gray-100 p-2 rounded-lg" onClick={handleClose}>
+                    <XIcon />
+                </div>
+                <h1 className="text-2xl font-bold">Invoice History</h1>
+                <p className="text-sm text-gray-500 mt-1">No invoice details available.</p>
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/selected-user.tsx
+++ b/frontend/src/components/selected-user.tsx
@@ -11,6 +11,7 @@ import { UserClientModel } from "../models/user-client.model";
 import { useState } from "react";
 import { Box, Calendar } from "lucide-react";
 import { RestocksModal } from "./restocks-modal";
+import { InvoiceHistoryModal } from "./invoice-history-modal";
 import { SupplierDataModel } from "@/features/suppliers/get-all-suppliers.model";
 
 type UserType = "customer" | "supplier" | "employee";
@@ -25,6 +26,9 @@ export const SelectedUser = ({
   handleEdit,
   ...user
 }: SelectedUserProps & { handleEdit: () => void }) => {
+  const [isInvoiceHistoryModalOpen, setIsInvoiceHistoryModalOpen] = useState(false);
+  const amountInReceivables = 5000; // scaffold placeholder
+
   return (
     <div className="flex flex-col p-5 w-full gap-2">
       <div className="flex items-center justify-between">
@@ -52,6 +56,29 @@ export const SelectedUser = ({
       </div>
 
       <Separator />
+
+      {/* amount in receivables SECTION */}
+      <div
+        className="p-2 rounded-lg bg-wash-gray hover:cursor-pointer hover:shadow-md transition-shadow"
+        onClick={() => setIsInvoiceHistoryModalOpen(true)}
+      >
+        <div className=" flex items-center gap-3">
+          <div className="bg-green-200 h-10 w-10 rounded-lg flex items-center justify-center text-blouse-gray">
+            <span className="text-green-500 font-bold">₱</span>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col justify-center gap-1 ">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold info-name flex gap-2">
+                ₱{amountInReceivables.toLocaleString()}
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <p className="info-id text-sm">Amount in Receivables</p>
+              <RightUpArrowIcon width={18} height={18} className="text-vesper-gray" />
+            </div>
+          </div>
+        </div>
+      </div>
 
       {/* user FULLNAME SECTION */}
       <div className="p-2 rounded-lg bg-wash-gray">
@@ -128,6 +155,10 @@ export const SelectedUser = ({
           </div>
         </div>
       </div>
+
+      {isInvoiceHistoryModalOpen && (
+        <InvoiceHistoryModal setIsInvoiceHistoryModalOpen={setIsInvoiceHistoryModalOpen} />
+      )}
 
       {/* USER ACTIONS SECTION */}
       {type === "supplier" && <SupplierActions />}

--- a/frontend/src/pages/admin/customers/_components/forms/add-customer.form.tsx
+++ b/frontend/src/pages/admin/customers/_components/forms/add-customer.form.tsx
@@ -116,39 +116,37 @@ export const AddCustomerForm = ({ onSuccess }: AddCustomerFormProps) => {
           </div>
         </div>
 
-        {/* REPRESENTATIVE SECTION HEADER */}
-        <div className="pt-2">
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label className="block text-sm font-medium text-gray-700">
             Representative
           </label>
-        </div>
+          <div className="flex w-full justify-between gap-4">
+            <div className="flex flex-col w-full">
+              <input
+                id="firstName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="First Name"
+                {...register("firstName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.firstName?.message}
+              </span>
+            </div>
 
-        {/* FIRST NAME AND LAST NAME */}
-        <div className="flex w-full justify-between gap-4">
-          <div className="flex flex-col w-full">
-            <input
-              id="firstName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="First Name"
-              {...register("firstName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.firstName?.message}
-            </span>
-          </div>
-
-          <div className="flex flex-col w-full">
-            <input
-              id="lastName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="Last Name"
-              {...register("lastName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.lastName?.message}
-            </span>
+            <div className="flex flex-col w-full">
+              <input
+                id="lastName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="Last Name"
+                {...register("lastName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.lastName?.message}
+              </span>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/admin/customers/_components/forms/edit.customer.form.tsx
+++ b/frontend/src/pages/admin/customers/_components/forms/edit.customer.form.tsx
@@ -128,39 +128,37 @@ export const EditCustomerForm = ({
           </div>
         </div>
 
-        {/* REPRESENTATIVE SECTION HEADER */}
-        <div className="pt-2">
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label className="block text-sm font-medium text-gray-700">
             Representative
           </label>
-        </div>
+          <div className="flex w-full justify-between gap-4">
+            <div className="flex flex-col w-full">
+              <input
+                id="firstName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="First Name"
+                {...register("firstName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.firstName?.message}
+              </span>
+            </div>
 
-        {/* FIRST NAME AND LAST NAME */}
-        <div className="flex w-full justify-between gap-4">
-          <div className="flex flex-col w-full">
-            <input
-              id="firstName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="First Name"
-              {...register("firstName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.firstName?.message}
-            </span>
-          </div>
-
-          <div className="flex flex-col w-full">
-            <input
-              id="lastName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="Last Name"
-              {...register("lastName")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.lastName?.message}
-            </span>
+            <div className="flex flex-col w-full">
+              <input
+                id="lastName"
+                type="text"
+                className="w-full drop-shadow-none bg-custom-gray p-2"
+                placeholder="Last Name"
+                {...register("lastName")}
+              />
+              <span className="text-red-500 text-xs normal-case">
+                {errors.lastName?.message}
+              </span>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/admin/employees/_components/forms/add-employee.form.tsx
+++ b/frontend/src/pages/admin/employees/_components/forms/add-employee.form.tsx
@@ -42,6 +42,7 @@ export const AddEmployeeForm = ({ setIsAddEmployeeModalOpen }: AddEmployeeFormPr
       roleID: 2,
       username: "",
       password: "",
+      companyName: "Prince Educational Supply",
     },
   });
 
@@ -63,52 +64,16 @@ export const AddEmployeeForm = ({ setIsAddEmployeeModalOpen }: AddEmployeeFormPr
       onSubmit={handleSubmit(onSubmit)}
     >
       <div className="flex flex-col space-y-4 mb-auto">
-        {/* LOGIN DETAILS */}
+        <input
+          type="hidden"
+          value="Prince Educational Supply"
+          {...register("companyName")}
+        />
 
         <div className="flex w-full justify-between gap-4">
-          {/* USERNAME*/}
           <div className="flex flex-col w-full">
             <label htmlFor="firstName" className="block text-sm font-medium">
-              Username
-            </label>
-            <input
-              id="firstName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="AUTO GENERATED"
-              disabled
-              {...register("username")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.username?.message}
-            </span>
-          </div>
-
-          {/* PASSWORD */}
-          <div className="flex flex-col w-full">
-            <label htmlFor="password" className="block text-sm font-medium">
-              Password
-            </label>
-            <input
-              id="password"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="AUTO GENERATED"
-              disabled
-              {...register("password")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.password?.message}
-            </span>
-          </div>
-        </div>
-
-        {/* SUPPLIER NAME */}
-        <div className="flex w-full justify-between gap-4">
-          {/* FIRST NAME */}
-          <div className="flex flex-col w-full">
-            <label htmlFor="firstName" className="block text-sm font-medium">
-              First Name
+              First Name <span className="text-red-500">*</span>
             </label>
             <input
               id="firstName"
@@ -120,11 +85,9 @@ export const AddEmployeeForm = ({ setIsAddEmployeeModalOpen }: AddEmployeeFormPr
               {errors.firstName?.message}
             </span>
           </div>
-
-          {/* LAST NAME */}
           <div className="flex flex-col w-full">
             <label htmlFor="lastName" className="block text-sm font-medium">
-              Last Name
+              Last Name <span className="text-red-500">*</span>
             </label>
             <input
               id="lastName"
@@ -140,25 +103,7 @@ export const AddEmployeeForm = ({ setIsAddEmployeeModalOpen }: AddEmployeeFormPr
 
         <div className="flex w-full justify-between gap-4">
           <div className="flex flex-col w-full">
-            <label htmlFor="emailAddress" className="block text-sm font-medium">
-              Email Address
-            </label>
-            <input
-              id="emailAddress"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              {...register("email")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.email?.message}
-            </span>
-          </div>
-
-          <div className="flex flex-col w-full">
-            <label
-              htmlFor="contactNumber"
-              className="block text-sm font-medium"
-            >
+            <label htmlFor="contactNumber" className="block text-sm font-medium">
               Contact Number
             </label>
             <input
@@ -171,25 +116,22 @@ export const AddEmployeeForm = ({ setIsAddEmployeeModalOpen }: AddEmployeeFormPr
               {errors.phoneNumber?.message}
             </span>
           </div>
+          <div className="flex flex-col w-full">
+            <label htmlFor="emailAddress" className="block text-sm font-medium">
+              Email
+            </label>
+            <input
+              id="emailAddress"
+              type="text"
+              className="w-full drop-shadow-none bg-custom-gray p-2"
+              {...register("email")}
+            />
+            <span className="text-red-500 text-xs normal-case">
+              {errors.email?.message}
+            </span>
+          </div>
         </div>
 
-        {/* COMPANY NAME */}
-        <div className="flex flex-col w-full">
-          <label htmlFor="companyName" className="block text-sm font-medium">
-            Company Name
-          </label>
-          <input
-            id="companyName"
-            type="text"
-            className="w-full drop-shadow-none bg-custom-gray p-2"
-            {...register("companyName")}
-          />
-          <span className="text-red-500 text-xs normal-case">
-            {errors.companyName?.message}
-          </span>
-        </div>
-
-        {/* ADDRESS */}
         <div className="flex flex-col w-full">
           <label htmlFor="address" className="block text-sm font-medium">
             Address
@@ -205,28 +147,50 @@ export const AddEmployeeForm = ({ setIsAddEmployeeModalOpen }: AddEmployeeFormPr
           </span>
         </div>
 
-        {/* ROLE */}
-        <div className="flex flex-col w-full">
-          <label htmlFor="role" className="block text-sm font-medium">
-            Role
-          </label>
-          <input
-            id="role"
-            type="text"
-            className="w-full drop-shadow-none bg-custom-gray p-2"
-            disabled
-            placeholder="EMPLOYEE"
-          // {...register("role")}
-          />
+        <div className="flex w-full justify-between gap-4">
+          <div className="flex flex-col w-full">
+            <label htmlFor="username" className="block text-sm font-medium">
+              Username <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="username"
+              type="text"
+              className="w-full drop-shadow-none bg-custom-gray p-2"
+              placeholder="AUTO GENERATED"
+              disabled
+              {...register("username")}
+            />
+            <span className="text-red-500 text-xs normal-case">
+              {errors.username?.message}
+            </span>
+          </div>
+
+          <div className="flex flex-col w-full">
+            <label htmlFor="password" className="block text-sm font-medium">
+              Password <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="password"
+              type="text"
+              className="w-full drop-shadow-none bg-custom-gray p-2"
+              placeholder="AUTO GENERATED"
+              disabled
+              {...register("password")}
+            />
+            <span className="text-red-500 text-xs normal-case">
+              {errors.password?.message}
+            </span>
+          </div>
         </div>
-        {/* DESCRIPTION */}
-        <div>
+
+        <div className="flex flex-col w-full">
           <label htmlFor="employeeNotes" className="block text-sm font-medium">
-            Employee Notes
+            Employee notes
           </label>
           <textarea
             id="employeeNotes"
-            className="w-full p-2 rounded-lg "
+            className="w-full p-2 rounded-lg"
+            placeholder="About the employee..."
             {...register("notes")}
           />
           <span className="text-red-500 text-xs normal-case">

--- a/frontend/src/pages/admin/employees/_components/forms/edit-employee.form.tsx
+++ b/frontend/src/pages/admin/employees/_components/forms/edit-employee.form.tsx
@@ -117,52 +117,16 @@ export const EditEmployeeForm = ({
       onSubmit={handleSubmit(onSubmit)}
     >
       <div className="flex flex-col space-y-4 mb-auto">
-        {/* LOGIN DETAILS */}
+        <input
+          type="hidden"
+          value="Prince Educational Supply"
+          {...register("companyName")}
+        />
 
         <div className="flex w-full justify-between gap-4">
-          {/* USERNAME*/}
           <div className="flex flex-col w-full">
             <label htmlFor="firstName" className="block text-sm font-medium">
-              Username
-            </label>
-            <input
-              id="firstName"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="AUTO GENERATED"
-              disabled
-              {...register("username")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.username?.message}
-            </span>
-          </div>
-
-          {/* PASSWORD */}
-          <div className="flex flex-col w-full">
-            <label htmlFor="password" className="block text-sm font-medium">
-              Password
-            </label>
-            <input
-              id="password"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              placeholder="AUTO GENERATED"
-              disabled
-              {...register("password")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.password?.message}
-            </span>
-          </div>
-        </div>
-
-        {/* SUPPLIER NAME */}
-        <div className="flex w-full justify-between gap-4">
-          {/* FIRST NAME */}
-          <div className="flex flex-col w-full">
-            <label htmlFor="firstName" className="block text-sm font-medium">
-              First Name
+              First Name <span className="text-red-500">*</span>
             </label>
             <input
               id="firstName"
@@ -174,11 +138,9 @@ export const EditEmployeeForm = ({
               {errors.firstName?.message}
             </span>
           </div>
-
-          {/* LAST NAME */}
           <div className="flex flex-col w-full">
             <label htmlFor="lastName" className="block text-sm font-medium">
-              Last Name
+              Last Name <span className="text-red-500">*</span>
             </label>
             <input
               id="lastName"
@@ -194,25 +156,7 @@ export const EditEmployeeForm = ({
 
         <div className="flex w-full justify-between gap-4">
           <div className="flex flex-col w-full">
-            <label htmlFor="emailAddress" className="block text-sm font-medium">
-              Email Address
-            </label>
-            <input
-              id="emailAddress"
-              type="text"
-              className="w-full drop-shadow-none bg-custom-gray p-2"
-              {...register("email")}
-            />
-            <span className="text-red-500 text-xs normal-case">
-              {errors.email?.message}
-            </span>
-          </div>
-
-          <div className="flex flex-col w-full">
-            <label
-              htmlFor="contactNumber"
-              className="block text-sm font-medium"
-            >
+            <label htmlFor="contactNumber" className="block text-sm font-medium">
               Contact Number
             </label>
             <input
@@ -225,25 +169,22 @@ export const EditEmployeeForm = ({
               {errors.phoneNumber?.message}
             </span>
           </div>
+          <div className="flex flex-col w-full">
+            <label htmlFor="emailAddress" className="block text-sm font-medium">
+              Email
+            </label>
+            <input
+              id="emailAddress"
+              type="text"
+              className="w-full drop-shadow-none bg-custom-gray p-2"
+              {...register("email")}
+            />
+            <span className="text-red-500 text-xs normal-case">
+              {errors.email?.message}
+            </span>
+          </div>
         </div>
 
-        {/* COMPANY NAME */}
-        <div className="flex flex-col w-full">
-          <label htmlFor="companyName" className="block text-sm font-medium">
-            Company Name
-          </label>
-          <input
-            id="companyName"
-            type="text"
-            className="w-full drop-shadow-none bg-custom-gray p-2"
-            {...register("companyName")}
-          />
-          <span className="text-red-500 text-xs normal-case">
-            {errors.companyName?.message}
-          </span>
-        </div>
-
-        {/* ADDRESS */}
         <div className="flex flex-col w-full">
           <label htmlFor="address" className="block text-sm font-medium">
             Address
@@ -259,28 +200,49 @@ export const EditEmployeeForm = ({
           </span>
         </div>
 
-        {/* ROLE */}
-        <div className="flex flex-col w-full">
-          <label htmlFor="role" className="block text-sm font-medium">
-            Role
-          </label>
-          <input
-            id="role"
-            type="text"
-            className="w-full drop-shadow-none bg-custom-gray p-2"
-            disabled
-            placeholder="EMPLOYEE"
-          // {...register("role")}
-          />
+        <div className="flex w-full justify-between gap-4">
+          <div className="flex flex-col w-full">
+            <label htmlFor="username" className="block text-sm font-medium">
+              Username <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="username"
+              type="text"
+              className="w-full drop-shadow-none bg-custom-gray p-2"
+              placeholder="AUTO GENERATED"
+              disabled
+              {...register("username")}
+            />
+            <span className="text-red-500 text-xs normal-case">
+              {errors.username?.message}
+            </span>
+          </div>
+          <div className="flex flex-col w-full">
+            <label htmlFor="password" className="block text-sm font-medium">
+              Password <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="password"
+              type="text"
+              className="w-full drop-shadow-none bg-custom-gray p-2"
+              placeholder="AUTO GENERATED"
+              disabled
+              {...register("password")}
+            />
+            <span className="text-red-500 text-xs normal-case">
+              {errors.password?.message}
+            </span>
+          </div>
         </div>
-        {/* DESCRIPTION */}
-        <div>
+
+        <div className="flex flex-col w-full">
           <label htmlFor="employeeNotes" className="block text-sm font-medium">
-            Employee Notes
+            Employee notes
           </label>
           <textarea
             id="employeeNotes"
-            className="w-full p-2 rounded-lg "
+            className="w-full p-2 rounded-lg"
+            placeholder="About the employee..."
             {...register("notes")}
           />
           <span className="text-red-500 text-xs normal-case">

--- a/frontend/src/pages/admin/suppliers/_components/forms/add-supplier.form.tsx
+++ b/frontend/src/pages/admin/suppliers/_components/forms/add-supplier.form.tsx
@@ -90,9 +90,8 @@ export const AddSupplierForm = ({
           </span>
         </div>
 
-        {/* SUPPLIER NAME */}
-        <div className="flex flex-col w-full justify-between gap-2">
-          {/* FIRST NAME */}
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label htmlFor="firstName" className="block text-sm font-medium">
             Representative
           </label>

--- a/frontend/src/pages/admin/suppliers/_components/forms/edit-supplier.form.tsx
+++ b/frontend/src/pages/admin/suppliers/_components/forms/edit-supplier.form.tsx
@@ -104,8 +104,8 @@ export const EditSupplierForm = ({
           />
         </div>
 
-        {/* SUPPLIER NAME */}
-        <div className="flex flex-col w-full justify-between gap-2">
+        {/* REPRESENTATIVE */}
+        <div className="flex flex-col w-full gap-2">
           <label htmlFor="firstName" className="block text-sm font-medium">
             Representative
           </label>

--- a/frontend/src/pages/admin/suppliers/_components/purchase-order-print.modal.tsx
+++ b/frontend/src/pages/admin/suppliers/_components/purchase-order-print.modal.tsx
@@ -2,7 +2,7 @@ import { Separator } from "@/components/separator";
 import { PurchaseOrderRecord } from "@/features/purchase-order/purchase-order.model";
 import { XIcon } from "@/icons";
 import { format } from "date-fns";
-import { PhilippinePeso } from "lucide-react";
+// [CHANGED] Removed: import { PhilippinePeso } from "lucide-react";
 import jsPDF from "jspdf";
 import { toast } from "sonner";
 
@@ -15,13 +15,16 @@ export const PurchaseOrderPreview = ({
   purchaseOrder,
   closeModal,
 }: PurchaseOrderPreviewProps) => {
+  // Formats currency with explicit ₱ unicode escape sequence to ensure
+  // consistent rendering across all environments (fixes ± fallback issues).
   const formatMoney = (value: number) => {
-    return new Intl.NumberFormat("en-PH", {
-      style: "currency",
-      currency: "PHP",
+    const amount = Number.isFinite(value) ? value : 0;
+    const sign = amount < 0 ? "-" : "";
+    const grouped = new Intl.NumberFormat("en-PH", {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
-    }).format(value);
+    }).format(Math.abs(amount));
+    return `${sign}\u20B1${grouped}`;
   };
 
   const formatDate = (value: string) => {
@@ -41,133 +44,366 @@ export const PurchaseOrderPreview = ({
       const pageHeight = doc.internal.pageSize.getHeight();
       const left = 14;
       const right = pageWidth - 14;
+      const contentWidth = right - left;
       let y = 14;
 
       const pushNewPageIfNeeded = (requiredSpace = 8) => {
         if (y + requiredSpace <= pageHeight - 14) return;
         doc.addPage();
-        y = 14;
+        y = 10;
       };
 
+      const headerColor = "#1F4B76";
+      const tableHeaderColor = "#366282";
+      const gridColor = "#B8CDE1";
+
+      const formatMoneyForPdf = (value: number) => {
+        const amount = Number.isFinite(value) ? value : 0;
+        const sign = amount < 0 ? "-" : "";
+        const grouped = new Intl.NumberFormat("en-PH", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        }).format(Math.abs(amount));
+        return `${sign}\u20B1${grouped}`;
+      };
+
+      const fitFontSizeToWidth = (
+        text: string,
+        maxWidth: number,
+        initialSize = 9,
+        minSize = 6.5
+      ) => {
+        let size = initialSize;
+        doc.setFontSize(size);
+        while (size > minSize && doc.getTextWidth(text) > maxWidth) {
+          size -= 0.5;
+          doc.setFontSize(size);
+        }
+        return size;
+      };
+
+      // HEADER SECTION
       doc.setFont("helvetica", "bold");
       doc.setFontSize(16);
+      doc.setTextColor(headerColor);
       doc.text("PRINCE", left, y);
-      doc.setFontSize(14);
+
+      // Company info below PRINCE
+      doc.setFont("helvetica", "normal");
+      doc.setFontSize(9);
+      doc.text("[Street Address]", left, y + 7);
+      doc.text("[City, State, ZIP]", left, y + 12);
+      doc.text("Contact No: XXX-XXXX", left, y + 17);
+      doc.text("Email: email@domain.com", left, y + 22);
+
+      // PURCHASE ORDER on right with underline
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(16);
+      doc.setTextColor(headerColor);
       doc.text("PURCHASE ORDER", right, y, { align: "right" });
+      const titleWidth = doc.getTextWidth("PURCHASE ORDER");
+      doc.setDrawColor(headerColor);
+      doc.setLineWidth(0.45);
+      doc.line(right - titleWidth, y + 1.8, right, y + 1.8);
 
-      y += 7;
-      doc.setFont("helvetica", "normal");
+      // P.O. # and Date directly below PURCHASE ORDER
+      const poLabelX = right - 62;
+      const poValueX = right;
+      const poValueWidth = 50;
+
+      doc.setFont("helvetica", "bold");
       doc.setFontSize(10);
-      doc.text("[Street Address]", left, y);
-      y += 4;
-      doc.text("[City, State, ZIP]", left, y);
-      y += 4;
-      doc.text("[Phone Number]", left, y);
-      y += 4;
-      doc.text("[Email Address]", left, y);
-
-      doc.text(`P.O. #: ${purchaseOrder.purchase_Order_Number}`, right, y - 8, {
+      doc.text("P.O. #:", poLabelX, y + 10, { align: "left" });
+      doc.setFont("helvetica", "normal");
+      doc.text(purchaseOrder.purchase_Order_Number || "-", poValueX, y + 10, {
         align: "right",
-      });
-      doc.text(`Date: ${formatDate(purchaseOrder.created_At)}`, right, y - 4, {
-        align: "right",
+        maxWidth: poValueWidth,
       });
 
-      y += 4;
-      doc.setDrawColor(180);
+      doc.setFont("helvetica", "bold");
+      doc.text("Date:", poLabelX, y + 16, { align: "left" });
+      doc.setFont("helvetica", "normal");
+      doc.text(formatDate(purchaseOrder.created_At), poValueX, y + 16, {
+        align: "right",
+        maxWidth: poValueWidth,
+      });
+
+      y += 29;
+
+      // Header separator
+      doc.setDrawColor(tableHeaderColor);
+      doc.setLineWidth(1.1);
       doc.line(left, y, right, y);
-      y += 6;
 
-      doc.setFont("helvetica", "bold");
-      doc.text("Supplier:", left, y);
-      doc.setFont("helvetica", "normal");
-      doc.text(purchaseOrder.supplier.company_Name || "-", left + 18, y);
+      y += 9;
 
-      doc.setFont("helvetica", "bold");
-      doc.text("Deliver To:", right - 48, y);
-      doc.setFont("helvetica", "normal");
-      doc.text("[Address]", right, y, { align: "right" });
+      // SUPPLIER/BUYER AND DELIVER TO SECTION
+      const midColumn = left + contentWidth / 2;
+      const leftValueX = left + 24;
+      const rightValueX = right;
+      const detailRowGap = 9;
+      const detailDividerTop = y - 3;
+      const detailDividerBottom = y + detailRowGap + 3;
 
-      y += 6;
+      doc.setDrawColor("#D4DCE5");
+      doc.setLineWidth(0.2);
+      doc.line(midColumn - 3, detailDividerTop, midColumn - 3, detailDividerBottom);
+
+      // Left column: SUPPLIER and BUYER
       doc.setFont("helvetica", "bold");
-      doc.text("Buyer:", left, y);
+      doc.setFontSize(10);
+      doc.setTextColor(headerColor);
+      doc.text("SUPPLIER:", left, y);
       doc.setFont("helvetica", "normal");
+      doc.setTextColor(0);
+      doc.text(purchaseOrder.supplier.company_Name || "-", leftValueX, y);
+
+      // Right column: DELIVER TO
+      doc.setFont("helvetica", "bold");
+      doc.setTextColor(headerColor);
+      doc.text("DELIVER TO:", midColumn, y);
+      doc.setFont("helvetica", "normal");
+      doc.setTextColor(0);
+      doc.text("[Address]", rightValueX, y, { align: "right" });
+
+      doc.setDrawColor("#D4DCE5");
+      doc.setLineWidth(0.2);
+      doc.line(left, y + 2.2, midColumn - 6, y + 2.2);
+      doc.line(midColumn, y + 2.2, right, y + 2.2);
+
+      y += detailRowGap;
+
+      // BUYER row
+      doc.setFont("helvetica", "bold");
+      doc.setTextColor(headerColor);
+      doc.text("BUYER:", left, y);
+      doc.setFont("helvetica", "normal");
+      doc.setTextColor(0);
       doc.text(
         `${purchaseOrder.clerk.first_Name} ${purchaseOrder.clerk.last_Name}`,
-        left + 12,
-        y,
+        leftValueX,
+        y
       );
 
+      // Please Deliver/Ship By row
       doc.setFont("helvetica", "bold");
-      doc.text("Deliver By:", right - 48, y);
+      doc.setTextColor(headerColor);
+      doc.text("Please Deliver/Ship By:", midColumn, y);
       doc.setFont("helvetica", "normal");
-      doc.text(formatDate(purchaseOrder.preferred_Delivery), right, y, {
+      doc.setTextColor(0);
+      doc.text(formatDate(purchaseOrder.preferred_Delivery), rightValueX, y, {
         align: "right",
       });
 
-      y += 6;
+      y += 7;
+
+      // HORIZONTAL LINE SEPARATOR
+      doc.setDrawColor(150);
+      doc.setLineWidth(0.3);
       doc.line(left, y, right, y);
+
       y += 6;
 
-      const colNo = left;
-      const colItem = left + 12;
-      const colQty = left + 114;
-      const colPrice = left + 136;
-      const colSubtotal = right;
+      // TABLE SECTION - Define columns carefully
+      const colWidths = {
+        no: 12,
+        item: 72,
+        qty: 20,
+        unit: 18,
+        price: 26,
+        subtotal: 34,
+      };
 
+      const colEdges = {
+        noStart: left,
+        noEnd: left + colWidths.no,
+        itemStart: left + colWidths.no,
+        itemEnd: left + colWidths.no + colWidths.item,
+        qtyStart: left + colWidths.no + colWidths.item,
+        qtyEnd: left + colWidths.no + colWidths.item + colWidths.qty,
+        unitStart: left + colWidths.no + colWidths.item + colWidths.qty,
+        unitEnd: left + colWidths.no + colWidths.item + colWidths.qty + colWidths.unit,
+        priceStart: left + colWidths.no + colWidths.item + colWidths.qty + colWidths.unit,
+        priceEnd:
+          left +
+          colWidths.no +
+          colWidths.item +
+          colWidths.qty +
+          colWidths.unit +
+          colWidths.price,
+        subtotalStart:
+          left +
+          colWidths.no +
+          colWidths.item +
+          colWidths.qty +
+          colWidths.unit +
+          colWidths.price,
+        subtotalEnd: right,
+      };
+
+      const colCenters = {
+        no: (colEdges.noStart + colEdges.noEnd) / 2,
+        qty: (colEdges.qtyStart + colEdges.qtyEnd) / 2,
+        unit: (colEdges.unitStart + colEdges.unitEnd) / 2,
+        price: (colEdges.priceStart + colEdges.priceEnd) / 2,
+        subtotal: (colEdges.subtotalStart + colEdges.subtotalEnd) / 2,
+      };
+
+      const rows = Math.max(10, purchaseOrder.line_Items.length);
+      const rowHeight = 6;
+      pushNewPageIfNeeded(8 + rows * rowHeight + 58);
+
+      // Table header
+      doc.setFillColor(tableHeaderColor);
+      doc.setDrawColor(tableHeaderColor);
+      doc.rect(left, y, contentWidth, 7, "F");
+
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(9);
+      doc.setTextColor(255);
+      doc.text("No.", colCenters.no, y + 4.8, { align: "center" });
+      doc.text("Item Description", colEdges.itemStart + 2, y + 4.8, {
+        align: "left",
+      });
+      doc.text("Quantity", colCenters.qty, y + 4.8, { align: "center" });
+      doc.text("Unit", colCenters.unit, y + 4.8, { align: "center" });
+      doc.text("Price", colCenters.price, y + 4.8, { align: "center" });
+      doc.text("Subtotal", colCenters.subtotal, y + 4.8, { align: "center" });
+
+      y += 7;
+
+      // Draw rows and strong grid lines
+      const tableBottomY = y + rows * rowHeight;
+
+      // Horizontal lines
+      doc.setDrawColor(gridColor);
+      doc.setLineWidth(0.3);
+      for (let i = 0; i <= rows; i++) {
+        doc.line(left, y + i * rowHeight, right, y + i * rowHeight);
+      }
+
+      // Vertical lines for columns
+      const vLines = [
+        colEdges.noStart,
+        colEdges.noEnd,
+        colEdges.itemEnd,
+        colEdges.qtyEnd,
+        colEdges.unitEnd,
+        colEdges.priceEnd,
+        colEdges.subtotalEnd,
+      ];
+      vLines.forEach((x) => {
+        doc.line(x, y, x, tableBottomY);
+      });
+
+      // Table data
+      doc.setFont("helvetica", "normal");
+      doc.setFontSize(9);
+      doc.setTextColor(0);
+      const cellPadding = 1.5;
+      const itemTextWidth = colWidths.item - cellPadding * 2;
+      const priceTextWidth = colWidths.price - cellPadding * 2;
+      const subtotalTextWidth = colWidths.subtotal - cellPadding * 2;
+
+      for (let i = 0; i < rows; i++) {
+        const rowY = y + i * rowHeight + 4;
+
+        if (i < purchaseOrder.line_Items.length) {
+          const line = purchaseOrder.line_Items[i];
+          const itemName = `${line.product?.product_Name || "-"} - ${line.product?.brand || "-"} - ${line.product?.variant || "-"}`;
+          const unitName = line.unit?.uom_Name ?? "-";
+          const itemText = doc.splitTextToSize(itemName, itemTextWidth)[0] || "-";
+
+          doc.text(String(i + 1), colCenters.no, rowY, { align: "center" });
+          doc.text(itemText, colEdges.itemStart + cellPadding, rowY, { align: "left" });
+          doc.text(String(line.quantity ?? 0), colCenters.qty, rowY, {
+            align: "center",
+          });
+          doc.text(unitName, colCenters.unit, rowY, { align: "center" });
+
+          // Format price and subtotal with ₱ symbol using explicit unicode escape
+          const priceStr = formatMoneyForPdf(Number(line.unit_Price ?? 0));
+          const subtotalStr = formatMoneyForPdf(Number(line.sub_Total ?? 0));
+
+          const baseFontSize = doc.getFontSize();
+
+          // Fit price text to available width, accounting for currency symbol
+          fitFontSizeToWidth(priceStr, priceTextWidth, 8.5, 6);
+          doc.text(priceStr, colEdges.priceEnd - cellPadding, rowY, {
+            align: "right",
+          });
+          doc.setFontSize(baseFontSize);
+
+          // Fit subtotal text to available width, accounting for currency symbol
+          fitFontSizeToWidth(subtotalStr, subtotalTextWidth, 8.5, 6);
+          doc.text(subtotalStr, colEdges.subtotalEnd - cellPadding, rowY, {
+            align: "right",
+          });
+          doc.setFontSize(baseFontSize);
+        }
+      }
+
+      y = tableBottomY + 7;
+
+      // TOTAL SECTION
+      pushNewPageIfNeeded(48);
+
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(12);
+      doc.setTextColor(0);
+
+      // Total row and boxed amount
+      const totalRowHeight = 10;
+      const totalBoxWidth = 42;
+      const totalBoxX = right - totalBoxWidth;
+      const totalValueY = y + totalRowHeight / 2 + 1.2;
+
+      doc.setDrawColor("#B8CDE1");
+      doc.setLineWidth(0.35);
+      doc.rect(left, y, contentWidth, totalRowHeight);
+
+      doc.text("Total:", totalBoxX - 6, totalValueY, { align: "right" });
+      doc.setDrawColor("#366282");
+      doc.setLineWidth(0.4);
+      doc.rect(totalBoxX, y, totalBoxWidth, totalRowHeight);
+
+      const totalStr = formatMoneyForPdf(Number(purchaseOrder.grand_Total ?? 0));
+      doc.setFont("helvetica", "normal");
+      const totalAvailableWidth = totalBoxWidth - 4;
+      fitFontSizeToWidth(totalStr, totalAvailableWidth, 10, 8);
+      doc.text(totalStr, totalBoxX + totalBoxWidth / 2, totalValueY, {
+        align: "center",
+      });
+      doc.setFontSize(10);
+
+      y += 15;
+
+      // NOTE SECTION
+      pushNewPageIfNeeded(48);
+
+      // Note header with background
+      doc.setFillColor("#E5EFFD");
+      doc.setDrawColor("#B8CDE1");
+      doc.setLineWidth(0.3);
+      doc.rect(left, y, contentWidth, 7, "FD");
       doc.setFont("helvetica", "bold");
       doc.setFontSize(10);
-      doc.text("No.", colNo, y);
-      doc.text("Item", colItem, y);
-      doc.text("Quantity", colQty, y, { align: "right" });
-      doc.text("Price", colPrice, y, { align: "right" });
-      doc.text("Subtotal", colSubtotal, y, { align: "right" });
-      y += 2;
-      doc.line(left, y, right, y);
-      y += 5;
+      doc.setTextColor(headerColor);
+      doc.text("NOTE", left + 2, y + 4.8);
+
+      y += 7;
+
+      // Note content box
+      doc.setDrawColor("#B8CDE1");
+      doc.setLineWidth(0.3);
+      const noteBoxHeight = 34;
+      doc.rect(left, y, contentWidth, noteBoxHeight);
 
       doc.setFont("helvetica", "normal");
-      purchaseOrder.line_Items.forEach((line, index) => {
-        const itemName = `${line.product?.product_Name || "-"} - ${line.product?.brand || "-"} - ${line.product?.variant || "-"}`;
-        const itemLines = doc.splitTextToSize(itemName, 95) as string[];
-        const rowHeight = Math.max(5, itemLines.length * 4);
-
-        pushNewPageIfNeeded(rowHeight + 4);
-
-        doc.text(String(index + 1), colNo, y);
-        doc.text(itemLines, colItem, y);
-        doc.text(String(line.quantity), colQty, y, { align: "right" });
-        doc.text(Number(line.unit_Price || 0).toFixed(2), colPrice, y, {
-          align: "right",
-        });
-        doc.text(formatMoney(Number(line.sub_Total || 0)), colSubtotal, y, {
-          align: "right",
-        });
-
-        y += rowHeight;
-        doc.setDrawColor(230);
-        doc.line(left, y, right, y);
-        y += 4;
-      });
-
-      pushNewPageIfNeeded(16);
-      doc.setFont("helvetica", "bold");
-      doc.text("Total:", right - 38, y);
-      doc.text(formatMoney(Number(purchaseOrder.grand_Total || 0)), right, y, {
-        align: "right",
-      });
-
-      y += 8;
-      pushNewPageIfNeeded(16);
-      doc.setFont("helvetica", "bold");
-      doc.text("Note", left, y);
-      y += 4;
-      doc.setFont("helvetica", "normal");
-      const noteText = doc.splitTextToSize(
-        purchaseOrder.notes || "-",
-        right - left,
-      );
-      doc.text(noteText, left, y);
+      doc.setFontSize(9);
+      doc.setTextColor(0);
+      const noteLines = doc.splitTextToSize(purchaseOrder.notes || "-", contentWidth - 4);
+      doc.text(noteLines, left + 2, y + 4);
 
       doc.save(`${purchaseOrder.purchase_Order_Number}.pdf`);
       toast.success("Purchase order PDF generated successfully.");
@@ -249,13 +485,25 @@ export const PurchaseOrderPreview = ({
               </div>
             </div>
 
+            {/* [CHANGED] Added table-fixed layout and explicit column widths to
+                prevent Price/Subtotal cells from overflowing into adjacent cells */}
             <div className="w-full h-full">
-              <table className="w-full text-sm">
+              <table className="w-full text-sm table-fixed">
+                <colgroup>
+                  <col className="w-8" />
+                  <col />
+                  <col className="w-20" />
+                  <col className="w-16" />
+                  {/* [CHANGED] Widened Price and Subtotal columns so values fit */}
+                  <col className="w-28" />
+                  <col className="w-28" />
+                </colgroup>
                 <thead>
                   <tr className="border-b">
                     <th className="text-left py-2">No.</th>
                     <th className="text-left py-2">Item</th>
                     <th className="text-right py-2">Quantity</th>
+                    <th className="text-right py-2">Unit</th>
                     <th className="text-right py-2">Price</th>
                     <th className="text-right py-2">Subtotal</th>
                   </tr>
@@ -267,19 +515,21 @@ export const PurchaseOrderPreview = ({
                       className="bg-white border-b"
                     >
                       <td className="text-center py-2">{index + 1}</td>
-                      <td className="py-2">
+                      <td className="py-2 break-words">
                         {line.product?.product_Name || "-"} -{" "}
                         {line.product?.brand || "-"} -{" "}
                         {line.product?.variant || "-"}
                       </td>
                       <td className="text-right py-2">{line.quantity}</td>
                       <td className="text-right py-2">
-                        <span className="inline-flex items-center gap-1 justify-end w-full">
-                          <PhilippinePeso size={14} />
-                          {Number(line.unit_Price || 0).toFixed(2)}
-                        </span>
+                        {line.unit?.uom_Name ?? "-"}
                       </td>
-                      <td className="text-right py-2">
+                      {/* [CHANGED] Removed PhilippinePeso icon; use ₱ text character.
+                          Added whitespace-nowrap so the value never wraps mid-number. */}
+                      <td className="text-right py-2 whitespace-nowrap">
+                        {formatMoney(Number(line.unit_Price || 0))}
+                      </td>
+                      <td className="text-right py-2 whitespace-nowrap">
                         {formatMoney(Number(line.sub_Total || 0))}
                       </td>
                     </tr>
@@ -288,9 +538,10 @@ export const PurchaseOrderPreview = ({
               </table>
             </div>
 
+            {/* [CHANGED] Total uses formatMoney (₱ text) instead of raw Intl output */}
             <div className="flex justify-end">
               <label className="font-bold">Total: </label>
-              <span className="ml-1">
+              <span className="ml-1 whitespace-nowrap">
                 {formatMoney(Number(purchaseOrder.grand_Total || 0))}
               </span>
             </div>


### PR DESCRIPTION
- Use PHP in formatMoneyForPdf to avoid jsPDF fallback rendering issues.
- Force table-fixed column sizing + whitespace-nowrap on Price/Subtotal so values don't overflow boundaries.

<img width="989" height="969" alt="image" src="https://github.com/user-attachments/assets/fc48d213-9e7e-493f-8434-90998fa98b89" />
