### PR TITLE
Refactor new invoice modal to use local mock data and simplified UI

### DIFF
--- a/frontend/src/pages/admin/invoice/new-invoice/_components/customer-picker.tsx
+++ b/frontend/src/pages/admin/invoice/new-invoice/_components/customer-picker.tsx
@@ -1,91 +1,29 @@
-import { useCustomersQuery } from "@/features/customers/customer-get-all.query";
-import {
-  updateSelectedCustomer,
-  useSelectedInvoiceCustomer,
-} from "@/features/invoice/invoice-customer.state";
-import { setInvoiceTermQuery } from "@/features/invoice/invoice-term.state";
+import { useState } from "react";
 
-import { useState, useRef, useEffect } from "react";
-
-type CustomerPickerProps = {
-  customersData?: any[];
-  placeholder?: string;
-};
-
-export const CustomerPicker = ({
-  customersData,
-  placeholder,
-}: CustomerPickerProps) => {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  const { data: fetchedCustomers } = useCustomersQuery();
-  const { data: selectedCustomer } = useSelectedInvoiceCustomer();
-  const { UPDATE_SELECTED_CUSTOMER } = updateSelectedCustomer();
-  const { UPDATE_INVOICE_TERM } = setInvoiceTermQuery();
-  const list = customersData ?? fetchedCustomers ?? [];
-
-  console.log(selectedCustomer);
-
-  useEffect(() => {
-    const onClick = (e: MouseEvent) => {
-      if (!ref.current) return;
-      if (!ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    window.addEventListener("click", onClick);
-    return () => window.removeEventListener("click", onClick);
-  }, []);
-
-  const filtered = list?.filter((c) =>
-    String(c.companyName).toLowerCase().includes(query.toLowerCase())
-  );
+export const CustomerPicker = () => {
+  const [customer, setCustomer] = useState("Prince Educational Supplies Inc.");
+  const [term, setTerm] = useState("Net 30");
 
   return (
-    <div className="flex flex-col w-full gap-2 relative" ref={ref}>
-      <label className="text-vesper-gray">Customer</label>
-      <div className="flex w-full">
+    <div className="flex flex-col w-full gap-2">
+      <label className="text-sm font-medium text-gray-700">Customer &amp; Term</label>
+      <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-2 w-full">
         <input
-          className="w-full rounded-r-none"
-          placeholder={placeholder ?? "Customer Name"}
-          value={selectedCustomer?.companyName ?? ""}
-          onFocus={() => setOpen(true)}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            setOpen(true);
-          }}
+          className="w-full rounded-lg border border-gray-300 bg-white"
+          value={customer}
+          onChange={(e) => setCustomer(e.target.value)}
+          placeholder="Customer Name"
         />
-        <input
-          placeholder="Term by days"
-          type="number"
-          className="rounded-l-none"
-          onChange={(e) => UPDATE_INVOICE_TERM(Number(e.target.value))}
-        />
+        <select
+          className="w-full rounded-lg border border-gray-300 bg-gray-50"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+        >
+          <option value="Net 30">Net 30</option>
+          <option value="Net 15">Net 15</option>
+          <option value="Due on Receipt">Due on Receipt</option>
+        </select>
       </div>
-
-      {open && (
-        <div className="absolute w-full bg-white top-20 max-h-64 overflow-y-auto border shadow-lg rounded-lg p-3">
-          {filtered && filtered.length > 0 ? (
-            filtered.map((customer, index) => (
-              <div
-                key={index}
-                className="p-2 hover:bg-gray-100 rounded-lg cursor-pointer"
-                onClick={() => {
-                  setQuery("");
-                  setOpen(false);
-                  UPDATE_SELECTED_CUSTOMER(customer);
-                }}
-              >
-                <div className="font-semibold">{customer.companyName}</div>
-                <div className="text-xs text-vesper-gray">{customer.email}</div>
-              </div>
-            ))
-          ) : (
-            <div className="text-vesper-gray">No customers found</div>
-          )}
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/admin/invoice/new-invoice/_components/invoice-modal-table.tsx
+++ b/frontend/src/pages/admin/invoice/new-invoice/_components/invoice-modal-table.tsx
@@ -1,121 +1,185 @@
-import { useAuth } from "@/context/use-auth";
-import { createInvoice } from "@/features/invoice/create-invoice.service";
-import {
-  useInvoicePayloadQuery,
-  useSelectedPayloadInvoiceQuery,
-} from "@/features/invoice/invoice-create-payload";
-import {
-  useSelectedInvoiceCustomer,
-  updateSelectedCustomer,
-} from "@/features/invoice/invoice-customer.state";
-import {
-  useInvoiceTermQuery,
-  setInvoiceTermQuery,
-} from "@/features/invoice/invoice-term.state";
 import { useState } from "react";
 
-export const InvoiceTable = ({ onSuccess }: { onSuccess?: () => void }) => {
-  const { data: payload = [] } = useSelectedPayloadInvoiceQuery();
-  const { data: selectedCustomer } = useSelectedInvoiceCustomer();
-  const { data: invoiceTerm } = useInvoiceTermQuery();
-  const { user } = useAuth();
-  const [isLoading, setIsLoading] = useState(false);
-  const { CLEAR_INVOICE_PAYLOAD } = useInvoicePayloadQuery();
-  const { CLEAR_SELECTED_CUSTOMER } = updateSelectedCustomer();
-  const { CLEAR_INVOICE_TERM } = setInvoiceTermQuery();
+type MockLineItem = {
+  product: string;
+  quantity: number;
+  unit: string;
+  price: number;
+  discount: string;
+  subtotal: number;
+  hasSupplement: boolean;
+  hasAutoReplenish: boolean;
+  primaryPreset: number;
+  supplementedPresets?: number[];
+  generatedPreset?: number;
+  pendingRestock?: boolean;
+};
 
-  console.log(payload);
+const mockLineItems: MockLineItem[] = [
+  {
+    product: "Item1 - Brand1 - Variant1",
+    quantity: 200,
+    unit: "Pack",
+    price: 300,
+    discount: "0%",
+    subtotal: 60000,
+    hasSupplement: true,
+    hasAutoReplenish: false,
+    primaryPreset: 60,
+    supplementedPresets: [60, 80],
+  },
+  {
+    product: "Item2 - Brand2 - Variant2",
+    quantity: 300,
+    unit: "Pack",
+    price: 200,
+    discount: "0%",
+    subtotal: 60000,
+    hasSupplement: false,
+    hasAutoReplenish: true,
+    primaryPreset: 60,
+    generatedPreset: 240,
+    pendingRestock: true,
+  },
+  {
+    product: "Item3 - Brand3 - Variant3",
+    quantity: 400,
+    unit: "Pack",
+    price: 100,
+    discount: "0%",
+    subtotal: 40000,
+    hasSupplement: true,
+    hasAutoReplenish: true,
+    primaryPreset: 60,
+    supplementedPresets: [60, 80],
+    generatedPreset: 200,
+  },
+];
 
-  const calculateInvoiceTotal = () => {
-    return payload.reduce((total, item) => total + item.invoice.total, 0);
-  };
+const FulfillmentTooltip = ({ item }: { item: MockLineItem }) => {
+  const supplementedValue = (item.supplementedPresets ?? []).join(" + ");
 
-  const calculateSubtotal = () => {
-    return payload.reduce(
-      (total, item) =>
-        total + item.invoice.unit_quantity * item.invoice.unit_price,
-      0,
-    );
-  };
+  return (
+    <div className="pointer-events-none absolute left-0 top-7 z-30 hidden min-w-96 rounded-md border border-gray-300 bg-white p-3 text-[11px] text-gray-700 shadow-xl group-hover:block">
+      <div className="font-semibold text-sm text-gray-900">Primary Preset</div>
+      <div className="mt-1 flex items-center justify-between">
+        <span>Box &gt; Pack (x10) &gt; Piece (x20)</span>
+        <span>{item.primaryPreset} Pack</span>
+      </div>
 
-  const handleCreateInvoice = async () => {
-    if (!selectedCustomer) {
-      alert("Please select a customer");
-      return;
-    }
+      {item.hasSupplement && (
+        <>
+          <div className="my-2 border-t border-dashed border-gray-400" />
+          <div className="font-semibold text-sm text-gray-900">Supplemented Preset</div>
+          <div className="mt-1 flex items-center justify-between">
+            <span>Crate &gt; Pack (x5) &gt; Piece (x20)</span>
+            <span>{(item.supplementedPresets ?? [])[0]} Pack</span>
+          </div>
+          <div className="mt-1 flex items-center justify-between">
+            <span>Pallet &gt; Pack (x8) &gt; Piece (x20)</span>
+            <span>{(item.supplementedPresets ?? [])[1]} Pack</span>
+          </div>
+        </>
+      )}
 
-    if (payload.length === 0) {
-      alert("Please add line items");
-      return;
-    }
+      {item.hasAutoReplenish && (
+        <>
+          <div className="my-2 border-t border-dashed border-gray-400" />
+          <div className="font-semibold text-sm text-gray-900">
+            Generated Preset (Restock #XXXXXX{item.pendingRestock ? " - pending" : ""})
+          </div>
+          <div className="mt-1 flex items-center justify-between">
+            <span>Pack &gt; Piece (x20)</span>
+            <span>{item.generatedPreset ?? 0} Pack</span>
+          </div>
+        </>
+      )}
 
-    setIsLoading(true);
-    try {
-      await createInvoice(
-        payload,
-        selectedCustomer?.id,
-        user?.user_ID,
-        invoiceTerm,
-      );
-      alert("Invoice created successfully!");
+      <div className="my-2 border-t border-dashed border-gray-400" />
+      <div className="flex items-center justify-between text-sm font-bold text-gray-900">
+        <span>Total</span>
+        <span>{item.quantity} Pack</span>
+      </div>
 
-      // Clear the payload and state after successful creation
-      CLEAR_INVOICE_PAYLOAD();
-      CLEAR_SELECTED_CUSTOMER();
-      CLEAR_INVOICE_TERM();
+      <div className="sr-only">
+        {item.hasSupplement ? `Supplemented amount ${supplementedValue}. ` : ""}
+        {item.hasAutoReplenish ? `Generated amount ${item.generatedPreset ?? 0}.` : ""}
+      </div>
+    </div>
+  );
+};
 
-      // Notify parent to close modal
-      if (onSuccess) {
-        onSuccess();
-      }
-    } catch (error) {
-      console.error("Error creating invoice:", error);
-      alert("Error creating invoice");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+export const InvoiceTable = () => {
+  const [discountValue, setDiscountValue] = useState("0");
+  const [discountType, setDiscountType] = useState<"%" | "amount">("%");
+
+  const subtotal = mockLineItems.reduce((total, item) => total + item.subtotal, 0);
+  const parsedDiscount = Number(discountValue) || 0;
+  const discountAmount =
+    discountType === "%"
+      ? subtotal * (parsedDiscount / 100)
+      : parsedDiscount;
+  const total = Math.max(0, subtotal - discountAmount);
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden gap-2">
       {/* TABLE DATA HEADERS */}
       <div className="flex justify-between py-3 px-5 bg-custom-gray rounded-lg gap-2">
-        <label className="text-left w-full">Item</label>
-
-        <label className="text-left w-full">Unit</label>
-        <label className="text-right w-full">Unit Price</label>
+        <label className="text-left w-full">Product</label>
         <label className="text-right w-full">Quantity</label>
+        <label className="text-left w-full">Unit</label>
+        <label className="text-right w-full">Price</label>
         <label className="text-right w-full">Discount</label>
         <label className="text-right w-full">Subtotal</label>
       </div>
 
+      <div className="flex flex-wrap items-center gap-4 px-1 text-[11px] font-light text-gray-500">
+        <div className="flex items-center gap-1">
+          <span className="text-red-500 font-semibold">⚯</span>
+          <span>Supplemented from other packaging presets</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-orange-500 font-semibold">⟳</span>
+          <span>Automatically replenish deficit</span>
+        </div>
+      </div>
+
       {/* TABLE DATA BODY */}
       <div className="overflow-auto flex flex-col h-full">
-        {payload && payload.length > 0 ? (
-          payload.map((item, i) => {
+        {mockLineItems.length > 0 ? (
+          mockLineItems.map((item, i) => {
             return (
               <div
-                className={`py-3 px-5 flex justify-between gap-2 rounded-lg items-center text-xs ${
-                  i % 2 != 0 && "bg-custom-gray"
-                }`}
+                className={`py-3 px-5 flex justify-between gap-2 rounded-lg items-center text-xs ${i % 2 != 0 && "bg-custom-gray"
+                  }`}
                 key={i}
               >
-                <span className="text-left w-full truncate">
-                  {item.invoice.product.product_Name}
+                <span className="text-left w-full relative">
+                  <span className="inline-flex items-center gap-1">
+                    <span>{item.product}</span>
+                    {(item.hasSupplement || item.hasAutoReplenish) && (
+                      <span className="relative group inline-flex items-center gap-1 align-middle">
+                        {item.hasSupplement && (
+                          <span className="text-red-500 text-sm leading-none">⚯</span>
+                        )}
+                        {item.hasAutoReplenish && (
+                          <span className="text-orange-500 text-sm leading-none">⟳</span>
+                        )}
+                        <FulfillmentTooltip item={item} />
+                      </span>
+                    )}
+                  </span>
                 </span>
-                <span className="text-left w-full">{item.invoice.unit}</span>
                 <span className="text-right w-full">
-                  ₱{item.invoice.unit_price.toFixed(2)}
+                  {item.quantity}
                 </span>
+                <span className="text-left w-full">{item.unit}</span>
                 <span className="text-right w-full">
-                  {item.invoice.unit_quantity}
+                  ₱{item.price.toLocaleString()}
                 </span>
+                <span className="text-right w-full">{item.discount}</span>
                 <span className="text-right w-full">
-                  {item.invoice.isDiscountPercentage
-                    ? `${item.invoice.discount}%`
-                    : `₱${item.invoice.discount.toFixed(2)}`}
-                </span>
-                <span className="text-right w-full">
-                  ₱{item.invoice.total.toFixed(2)}
+                  ₱{item.subtotal.toLocaleString()}
                 </span>
               </div>
             );
@@ -127,32 +191,35 @@ export const InvoiceTable = ({ onSuccess }: { onSuccess?: () => void }) => {
         )}
       </div>
 
-      <span className="text-vesper-gray text-xs">
-        Invoice will include {payload.length} item
-        {payload.length !== 1 ? "s" : ""}
-      </span>
-
-      <div className="flex justify-between">
+      <div className="flex justify-between items-end pt-2">
         <div className="flex flex-col gap-2">
-          <div className="flex gap-2 text-sm tracking-wider">
-            <span className="text-vesper-gray">Subtotal:</span>
-            <label className="font-semibold">
-              ₱{calculateSubtotal().toFixed(2)}
-            </label>
+          <div className="flex items-center gap-0 text-sm">
+            <span className="font-semibold mr-2">Discount</span>
+            <input
+              className="w-20 px-2 py-1 rounded-l border border-gray-300"
+              value={discountValue}
+              onChange={(e) => setDiscountValue(e.target.value)}
+            />
+            <select
+              className="w-14 px-1 py-1 rounded-r border border-l-0 border-gray-300 bg-white"
+              value={discountType}
+              onChange={(e) => setDiscountType(e.target.value as "%" | "amount")}
+            >
+              <option value="%">%</option>
+              <option value="amount">₱</option>
+            </select>
           </div>
 
-          <div className="flex gap-2 font-bold tracking-wider text-base">
+          <div className="flex gap-2 font-bold tracking-wider text-2xl">
             <span>TOTAL:</span>
-            <label>₱{calculateInvoiceTotal().toFixed(2)}</label>
+            <label>₱{total.toLocaleString()}</label>
           </div>
         </div>
 
         <button
-          onClick={handleCreateInvoice}
-          disabled={isLoading || payload.length === 0 || !selectedCustomer}
-          className="px-6 py-2 bg-blue-500 text-white rounded disabled:bg-gray-400 disabled:cursor-not-allowed"
+          className="px-8 py-2 border border-gray-800 bg-white text-gray-900 rounded hover:bg-gray-50"
         >
-          {isLoading ? "Creating..." : "Create Invoice"}
+          Save
         </button>
       </div>
     </div>

--- a/frontend/src/pages/admin/invoice/new-invoice/_components/invoice-modal.tsx
+++ b/frontend/src/pages/admin/invoice/new-invoice/_components/invoice-modal.tsx
@@ -1,9 +1,6 @@
 import { XIcon } from "@/icons";
 import { InvoiceTable } from "./invoice-modal-table";
-import { useCustomersQuery } from "@/features/customers/customer-get-all.query";
 import { CustomerPicker } from "./customer-picker";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 interface CreateInvoiceModalProps {
   createInvoice: () => void;
@@ -12,21 +9,8 @@ interface CreateInvoiceModalProps {
 export const CreateInvoiceModal = ({
   createInvoice,
 }: CreateInvoiceModalProps) => {
-  const navigate = useNavigate();
-  const { data: customersData } = useCustomersQuery();
-  const [invoiceCreated, setInvoiceCreated] = useState(false);
-
   const handleClose = () => {
-    setInvoiceCreated(false);
     createInvoice();
-  };
-
-  const handleInvoiceSuccess = () => {
-    setInvoiceCreated(true);
-    setTimeout(() => {
-      handleClose();
-      navigate("/admin/restock");
-    }, 1500);
   };
 
   return (
@@ -36,15 +20,14 @@ export const CreateInvoiceModal = ({
         if (e.target === e.currentTarget) handleClose();
       }}
     >
-      <div className="w-3/6 h-4/5 bg-white px-20 py-10 rounded-lg border shadow-lg">
+      <div className="w-4/5 h-4/5 bg-white px-10 py-8 rounded-lg border shadow-lg">
         <div className="flex flex-col gap-5 flex-1 h-full">
           {/* HEADER */}
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-2">
-              <h2 className="text-lg font-semibold">Order Confirmation</h2>
-              <span className="text-vesper-gray text-sm tracking-wider">
-                Invoice Details
-              </span>
+              <h2 className="text-2xl font-semibold tracking-wide">
+                Invoice Confirmation #XXXXX
+              </h2>
             </div>
             <div
               onClick={handleClose}
@@ -54,25 +37,11 @@ export const CreateInvoiceModal = ({
             </div>
           </div>
 
-          {invoiceCreated ? (
-            <div className="flex-1 flex items-center justify-center flex-col gap-4">
-              <div className="text-4xl">✅</div>
-              <h3 className="text-xl font-semibold text-green-600">
-                Invoice Created Successfully!
-              </h3>
-              <p className="text-vesper-gray text-sm">
-                Closing modal in a moment...
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* SEARCH CONTAINER */}
-              <CustomerPicker customersData={customersData} />
+          {/* SEARCH CONTAINER */}
+          <CustomerPicker />
 
-              {/* TABLE CONTAINER */}
-              <InvoiceTable onSuccess={handleInvoiceSuccess} />
-            </>
-          )}
+          {/* TABLE CONTAINER */}
+          <InvoiceTable />
         </div>
       </div>
     </div>


### PR DESCRIPTION
- remove customer/query state hooks and dynamic search from customer-picker
- replace invoice payload/actions with mock line items, discount logic, and fulfillment tooltip in invoice-modal-table
- simplify modal layout, close flow, and component props in invoice-modal