### PR TITLE
feat(ui): update Mark Delivery Status modal

### DIFF
--- a/frontend/src/pages/admin/restock/po-restock/_components/delivery-status-choice.modal.tsx
+++ b/frontend/src/pages/admin/restock/po-restock/_components/delivery-status-choice.modal.tsx
@@ -1,4 +1,5 @@
 import { PORestockDeliveryStatus } from "@/features/restock/models/po-restock.model";
+import { AlertTriangle, ChevronDown } from "lucide-react";
 
 interface DeliveryStatusChoiceModalProps {
   isPending: boolean;
@@ -13,74 +14,115 @@ export const DeliveryStatusChoiceModal = ({
 }: DeliveryStatusChoiceModalProps) => {
   return (
     <section className="absolute bg-black/40 w-full h-full top-0 left-0 flex justify-center items-center z-60">
-      <div className="w-[480px] bg-white px-8 py-7 rounded-lg border shadow-xl flex flex-col gap-6">
+      <div className="w-[760px] bg-white px-8 py-7 rounded-lg border shadow-xl flex flex-col gap-6">
         <div>
-          <h2 className="text-lg font-semibold">Mark Delivery Status</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-2xl font-bold text-[#0A1931]">Mark Delivery Status</h2>
+          <p className="text-base text-gray-500 mt-2">
             How would you like to mark this delivery?
           </p>
         </div>
 
+        <div className="border border-gray-200 rounded-lg overflow-hidden">
+          <div className="flex items-center gap-2 p-4 pb-2">
+            <AlertTriangle className="w-5 h-5 text-orange-500" />
+            <span className="font-semibold text-orange-500 text-sm tracking-wide">SHORT DELIVERIES</span>
+          </div>
+
+          <div className="px-4 pb-2">
+            <div className="max-h-[280px] overflow-y-auto pr-2 custom-scrollbar">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-gray-500 text-xs font-semibold">
+                    <th className="text-left font-semibold py-3">PRODUCT</th>
+                    <th className="text-left font-semibold py-3">PRESET CONVERSION</th>
+                    <th className="text-right font-semibold py-3">SHORT QTY (MAIN UNIT)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-4 text-gray-800 font-medium">Product A</td>
+                    <td className="py-4 text-gray-500">SET &rarr; PAD (90x) &rarr; PIECE (120x)</td>
+                    <td className="py-4 text-right text-orange-600 font-bold">2 SETS</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-4 text-gray-800 font-medium">Product B</td>
+                    <td className="py-4 text-gray-500">BOX &rarr; PACK (12x)</td>
+                    <td className="py-4 text-right text-orange-600 font-bold">1 BOX</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-4 text-gray-800 font-medium">Product C</td>
+                    <td className="py-4 text-gray-500">CASE &rarr; PACK (24x) &rarr; PIECE (240x)</td>
+                    <td className="py-4 text-right text-orange-600 font-bold">3 CASES</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-4 text-gray-800 font-medium">Product D</td>
+                    <td className="py-4 text-gray-500">KIT &rarr; PACK (10x) &rarr; PIECE (50x)</td>
+                    <td className="py-4 text-right text-orange-600 font-bold">5 KITS</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-4 text-gray-800 font-medium">Product E</td>
+                    <td className="py-4 text-gray-500">BUNDLE &rarr; PIECE (20x)</td>
+                    <td className="py-4 text-right text-orange-600 font-bold">1 BUNDLE</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-center py-3 border-t text-sm text-gray-500">
+            Showing 5 of 15 items <ChevronDown className="ml-1 w-4 h-4" />
+          </div>
+        </div>
+
         <div className="grid grid-cols-2 gap-4">
-          <div className="flex flex-col gap-2 p-3 rounded-lg">
-            <div className="flex items-center gap-2">
-              <div className="w-4 h-4 bg-yellow-300 rounded-full shrink-0" />
-              <label className="font-semibold text-yellow-800 text-sm">
-                Partial
+          <div className="flex flex-col p-5 rounded-lg border-2 border-yellow-200 bg-[#FFFDF5]">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-5 h-5 bg-[#FFC107] rounded-full shrink-0" />
+              <label className="font-bold text-[#A67C00] text-lg">
+                Partial Delivery
               </label>
             </div>
-            <p className="text-xs text-yellow-700">
+            <p className="text-sm text-[#A67C00] flex-grow leading-relaxed mb-6 font-medium">
               The PO stays open. Remaining quantities are remembered and will be
               pre-filled the next time you restock from this PO.
             </p>
+            <button
+              disabled={isPending}
+              onClick={() => onChoose("PARTIAL")}
+              className="text-center font-bold text-[#A67C00] disabled:opacity-50 hover:underline transition-all"
+            >
+              Mark As Partial Delivery
+            </button>
           </div>
 
-          <div className="flex flex-col gap-2 p-3 rounded-lg ">
-            <div className="flex items-center gap-2">
-              <div className="w-4 h-4 bg-green-300 rounded-full shrink-0" />
-              <label className="font-semibold text-green-800 text-sm">
-                Complete
+          <div className="flex flex-col p-5 rounded-lg border-2 border-green-200 bg-[#F5FFF9]">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-5 h-5 bg-[#4ADE80] rounded-full shrink-0" />
+              <label className="font-bold text-[#208350] text-lg">
+                Fully Delivered
               </label>
             </div>
-            <p className="text-xs text-green-700">
+            <p className="text-sm text-[#208350] flex-grow leading-relaxed mb-6 font-medium">
               Received items are added to inventory. Any remaining undelivered
-              quantities are waived. This PO will be closed and cannot be
-              reopened.
+              quantities are waived. This PO will be closed.
             </p>
+            <button
+              disabled={isPending}
+              onClick={() => onChoose("FULLY_DELIVERED")}
+              className="text-center font-bold text-[#208350] disabled:opacity-50 hover:underline transition-all"
+            >
+              Mark As Fully Delivered
+            </button>
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-3 w-full">
-          {/* Partial */}
+        <div className="flex justify-center mt-2">
           <button
-            disabled={isPending}
-            onClick={() => onChoose("PARTIAL")}
-            className="text-left p-4 rounded-lg border-2 border-yellow-300 bg-yellow-50 hover:bg-yellow-100 transition-all duration-300 disabled:opacity-50 w-full max-w-full"
-          >
-            <div className="font-semibold text-yellow-800">
-              Mark as Partial Delivery
-            </div>
-          </button>
-
-          {/* Fully delivered */}
-          <button
-            disabled={isPending}
-            onClick={() => onChoose("FULLY_DELIVERED")}
-            className="text-left p-4 rounded-lg border-2 border-green-300 bg-green-50 hover:bg-green-100 transition-all duration-300 disabled:opacity-50 w-full max-w-full"
-          >
-            <div className="font-semibold text-green-800">
-              Mark as Fully Delivered
-            </div>
-          </button>
-        </div>
-
-        <div className="flex justify-end">
-          <button
-            className="text-sm text-gray-500 hover:underline"
+            className="w-48 py-2.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none"
             onClick={onClose}
             disabled={isPending}
           >
-            Go back
+            Go Back
           </button>
         </div>
       </div>

--- a/frontend/src/pages/admin/restock/po-restock/_components/delivery-status-choice.modal.tsx
+++ b/frontend/src/pages/admin/restock/po-restock/_components/delivery-status-choice.modal.tsx
@@ -14,7 +14,7 @@ export const DeliveryStatusChoiceModal = ({
 }: DeliveryStatusChoiceModalProps) => {
   return (
     <section className="absolute bg-black/40 w-full h-full top-0 left-0 flex justify-center items-center z-60">
-      <div className="w-[760px] bg-white px-8 py-7 rounded-lg border shadow-xl flex flex-col gap-6">
+      <div className="w-[900px] max-w-[95vw] bg-white px-8 py-5 rounded-lg border shadow-xl flex flex-col gap-4">
         <div>
           <h2 className="text-2xl font-bold text-[#0A1931]">Mark Delivery Status</h2>
           <p className="text-base text-gray-500 mt-2">
@@ -29,7 +29,7 @@ export const DeliveryStatusChoiceModal = ({
           </div>
 
           <div className="px-4 pb-2">
-            <div className="max-h-[280px] overflow-y-auto pr-2 custom-scrollbar">
+            <div className="max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b text-gray-500 text-xs font-semibold">
@@ -82,14 +82,14 @@ export const DeliveryStatusChoiceModal = ({
                 Partial Delivery
               </label>
             </div>
-            <p className="text-sm text-[#A67C00] flex-grow leading-relaxed mb-6 font-medium">
+            <p className="text-sm text-[#A67C00] flex-grow leading-relaxed mb-4 font-medium">
               The PO stays open. Remaining quantities are remembered and will be
               pre-filled the next time you restock from this PO.
             </p>
             <button
               disabled={isPending}
               onClick={() => onChoose("PARTIAL")}
-              className="text-center font-bold text-[#A67C00] disabled:opacity-50 hover:underline transition-all"
+              className="self-center bg-transparent border-none outline-none whitespace-nowrap text-center font-bold text-[#A67C00] disabled:opacity-50 hover:underline transition-all"
             >
               Mark As Partial Delivery
             </button>
@@ -102,14 +102,14 @@ export const DeliveryStatusChoiceModal = ({
                 Fully Delivered
               </label>
             </div>
-            <p className="text-sm text-[#208350] flex-grow leading-relaxed mb-6 font-medium">
+            <p className="text-sm text-[#208350] flex-grow leading-relaxed mb-4 font-medium">
               Received items are added to inventory. Any remaining undelivered
               quantities are waived. This PO will be closed.
             </p>
             <button
               disabled={isPending}
               onClick={() => onChoose("FULLY_DELIVERED")}
-              className="text-center font-bold text-[#208350] disabled:opacity-50 hover:underline transition-all"
+              className="self-center bg-transparent border-none outline-none whitespace-nowrap text-center font-bold text-[#208350] disabled:opacity-50 hover:underline transition-all"
             >
               Mark As Fully Delivered
             </button>

--- a/frontend/src/pages/admin/restock/po-restock/_components/po-restock-confirm.modal.tsx
+++ b/frontend/src/pages/admin/restock/po-restock/_components/po-restock-confirm.modal.tsx
@@ -6,6 +6,7 @@ import { useCreatePORestockMutation } from "@/features/restock/po-restock.query"
 import { PORestockDeliveryStatus } from "@/features/restock/models/po-restock.model";
 import { PORestockCardState } from "../index";
 import { DeliveryStatusChoiceModal } from "./delivery-status-choice.modal";
+import { ChevronDown } from "lucide-react";
 
 interface PORestockConfirmModalProps {
   po: PurchaseOrderRecord;
@@ -89,10 +90,14 @@ export const PORestockConfirmModal = ({
         <div className="w-[820px] max-h-[90vh] overflow-y-auto bg-white px-10 py-8 rounded-lg border shadow-lg flex flex-col gap-4">
           {/* Header */}
           <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-2xl font-bold">Restock Confirmation</h1>
-              <span className="text-sm bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full border border-blue-200">
-                PO: {po.purchase_Order_Number}
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-[#1f2937]">Restock Confirmation</h1>
+              <span className="text-lg font-medium text-gray-500">
+                #{po.purchase_Order_Number}
+              </span>
+              <span className="text-gray-400">•</span>
+              <span className="text-xs bg-yellow-50 text-yellow-600 px-3 py-0.5 rounded-full border border-yellow-200 font-medium">
+                Partial
               </span>
             </div>
             <p className="text-gray-500 text-sm mt-1">
@@ -123,7 +128,7 @@ export const PORestockConfirmModal = ({
 
           {/* Items table */}
           <div className="rounded-lg border overflow-hidden">
-            <div className="grid grid-cols-12 gap-2 px-3 py-2 bg-custom-gray text-xs font-semibold uppercase">
+            <div className="grid grid-cols-12 gap-4 px-4 py-3 bg-gray-50/80 text-[11px] text-gray-500 font-bold uppercase tracking-wider border-b">
               <div className="col-span-3">Product</div>
               <div className="col-span-2 text-right">Ordered</div>
               <div className="col-span-2 text-right">Prev. Received</div>
@@ -136,38 +141,38 @@ export const PORestockConfirmModal = ({
               {lineItemRows.map((row, idx) => (
                 <div
                   key={row.lineItemId}
-                  className={`grid grid-cols-12 gap-2 px-3 py-2 text-xs ${
-                    row.removed ? "opacity-40 line-through" : ""
-                  } ${idx !== lineItemRows.length - 1 ? "border-b" : ""}`}
+                  className={`grid grid-cols-12 gap-4 px-4 py-4 text-xs items-center ${row.removed ? "opacity-40 line-through" : ""
+                    } ${idx !== lineItemRows.length - 1 ? "border-b border-gray-100" : ""}`}
                 >
-                  <div className="col-span-3">
-                    <div className="font-medium">{row.productName}</div>
-                    {row.presetName && (
-                      <div className="text-gray-400 text-xs">
-                        {row.presetName}
+                  <div className="col-span-3 flex flex-col gap-1">
+                    <div className="font-semibold text-gray-800 text-sm">
+                      {row.productName}{row.brand ? ` - ${row.brand}` : ""}
+                    </div>
+                    {row.presetCode && (
+                      <div className="text-gray-400 text-[11px] font-medium uppercase tracking-wide">
+                        {row.presetCode}
                       </div>
                     )}
                   </div>
-                  <div className="col-span-2 text-right">
+                  <div className="col-span-2 text-right font-medium text-gray-600">
                     {row.orderedQuantity}
                   </div>
-                  <div className="col-span-2 text-right text-gray-500">
+                  <div className="col-span-2 text-right font-medium text-gray-400">
                     {row.receivedSoFar}
                   </div>
-                  <div className="col-span-2 text-right">
+                  <div className="col-span-2 text-right font-medium text-gray-600">
                     {row.remainingQuantity}
                   </div>
-                  <div className="col-span-2 text-right font-medium">
+                  <div className="col-span-2 text-right font-bold text-gray-800">
                     {row.receivingQuantity}
                   </div>
                   <div
-                    className={`col-span-1 text-right font-semibold ${
-                      row.discrepancy > 0
+                    className={`col-span-1 text-right font-bold ${row.discrepancy > 0
                         ? "text-blue-600"
                         : row.discrepancy < 0
                           ? "text-red-500"
                           : "text-green-600"
-                    }`}
+                      }`}
                   >
                     {row.discrepancy > 0
                       ? `+${row.discrepancy}`
@@ -179,31 +184,35 @@ export const PORestockConfirmModal = ({
           </div>
 
           {/* Discrepancy legend */}
-          <div className="flex gap-4 text-xs text-gray-400">
+          <div className="flex gap-5 text-[13px] text-gray-500 font-medium">
             <span>
-              <span className="text-blue-600 font-semibold">+n</span>{" "}
-              over-delivery
+              <span className="text-blue-600 font-bold">+n</span> Over-Delivery
             </span>
             <span>
-              <span className="text-red-500 font-semibold">-n</span> short
-              delivery
+              <span className="text-red-500 font-bold">-n</span> Short Delivery
             </span>
             <span>
-              <span className="text-green-600 font-semibold">0</span> exact
-              match
+              <span className="text-green-600 font-bold">0</span> Exact Match
             </span>
           </div>
 
           {/* Notes */}
-          <div className="flex flex-col gap-1">
-            <label className="text-sm font-medium">Note</label>
-            <textarea
-              className="input-style-2 min-h-20"
-              placeholder="Add restock notes..."
-              value={notes}
-              onChange={(e) => onNotesChange(e.target.value)}
-            />
-          </div>
+          <details className="group border border-gray-200 rounded-md overflow-hidden bg-gray-50/50">
+            <summary className="flex text-sm cursor-pointer items-center justify-between px-4 py-3 font-semibold text-gray-700 hover:bg-gray-100 list-none [&::-webkit-details-marker]:hidden">
+              <span className="flex items-center gap-2">
+                Add restock notes
+              </span>
+              <ChevronDown className="w-4 h-4 text-gray-500 transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="p-4 bg-white border-t border-gray-200">
+              <textarea
+                className="input-style-2 min-h-20 w-full"
+                placeholder="Leave restock notes here..."
+                value={notes}
+                onChange={(e) => onNotesChange(e.target.value)}
+              />
+            </div>
+          </details>
 
           {/* Actions */}
           <div className="flex justify-end gap-3">


### PR DESCRIPTION
- Increased modal width to accommodate side-by-side components.
- Added styled "Short Deliveries" table featuring hardcoded test rows and warning header with `AlertTriangle`.
- Replaced original partial/complete option layouts with styled choice cards resembling the new design.
- Merged card copy and CTA buttons directly into the choice cards inline with the reference image.
- Centered the "Go Back" button with a rounded border outline.