### PR TITLE
style: update PO restock page layout and modal styling

### DIFF
--- a/frontend/src/pages/admin/restock/po-restock/_components/po-restock-confirm.modal.tsx
+++ b/frontend/src/pages/admin/restock/po-restock/_components/po-restock-confirm.modal.tsx
@@ -49,7 +49,7 @@ export const PORestockConfirmModal = ({
       lineItemId: card.lineItemId,
       productName: li?.product?.product_Name ?? "",
       brand: li?.product?.brand ?? "",
-      presetCode: li?.unit_Preset?.preset_Code ?? "",
+      presetCode: li?.unit_Preset?.preset_Levels?.map((l) => l.uom_Name).join(" → ") || li?.unit_Preset?.preset_Code || "",
       orderedQuantity: card.orderedQuantity,
       receivedSoFar: card.receivedQuantity,
       remainingQuantity: card.remainingQuantity,
@@ -129,19 +129,19 @@ export const PORestockConfirmModal = ({
           {/* Items table */}
           <div className="rounded-lg border overflow-hidden">
             <div className="grid grid-cols-12 gap-4 px-4 py-3 bg-gray-50/80 text-[11px] text-gray-500 font-bold uppercase tracking-wider border-b">
-              <div className="col-span-3">Product</div>
-              <div className="col-span-2 text-right">Ordered</div>
-              <div className="col-span-2 text-right">Prev. Received</div>
-              <div className="col-span-2 text-right">Remaining</div>
-              <div className="col-span-2 text-right">Receiving</div>
-              <div className="col-span-1 text-right">Disc.</div>
+              <div className="col-span-3 font-bold">PRODUCT</div>
+              <div className="col-span-2 text-center font-bold">ORDERED</div>
+              <div className="col-span-2 text-center font-bold">PREV. RECEIVED</div>
+              <div className="col-span-2 text-center font-bold">REMAINING</div>
+              <div className="col-span-2 text-center font-bold">RECEIVING</div>
+              <div className="col-span-1 text-center font-bold">DISC.</div>
             </div>
 
             <div className="max-h-64 overflow-y-auto">
               {lineItemRows.map((row, idx) => (
                 <div
                   key={row.lineItemId}
-                  className={`grid grid-cols-12 gap-4 px-4 py-4 text-xs items-center ${row.removed ? "opacity-40 line-through" : ""
+                  className={`grid grid-cols-12 gap-4 px-4 py-6 text-xs items-center ${row.removed ? "opacity-40 line-through" : ""
                     } ${idx !== lineItemRows.length - 1 ? "border-b border-gray-100" : ""}`}
                 >
                   <div className="col-span-3 flex flex-col gap-1">
@@ -154,20 +154,20 @@ export const PORestockConfirmModal = ({
                       </div>
                     )}
                   </div>
-                  <div className="col-span-2 text-right font-medium text-gray-600">
+                  <div className="col-span-2 text-center font-medium text-gray-600">
                     {row.orderedQuantity}
                   </div>
-                  <div className="col-span-2 text-right font-medium text-gray-400">
+                  <div className="col-span-2 text-center font-medium text-gray-400">
                     {row.receivedSoFar}
                   </div>
-                  <div className="col-span-2 text-right font-medium text-gray-600">
+                  <div className="col-span-2 text-center font-medium text-gray-600">
                     {row.remainingQuantity}
                   </div>
-                  <div className="col-span-2 text-right font-bold text-gray-800">
+                  <div className="col-span-2 text-center font-bold text-gray-800">
                     {row.receivingQuantity}
                   </div>
                   <div
-                    className={`col-span-1 text-right font-bold ${row.discrepancy > 0
+                    className={`col-span-1 text-center font-bold ${row.discrepancy > 0
                       ? "text-blue-600"
                       : row.discrepancy < 0
                         ? "text-red-500"

--- a/frontend/src/pages/admin/restock/po-restock/_components/po-restock-confirm.modal.tsx
+++ b/frontend/src/pages/admin/restock/po-restock/_components/po-restock-confirm.modal.tsx
@@ -6,7 +6,7 @@ import { useCreatePORestockMutation } from "@/features/restock/po-restock.query"
 import { PORestockDeliveryStatus } from "@/features/restock/models/po-restock.model";
 import { PORestockCardState } from "../index";
 import { DeliveryStatusChoiceModal } from "./delivery-status-choice.modal";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ClipboardList } from "lucide-react";
 
 interface PORestockConfirmModalProps {
   po: PurchaseOrderRecord;
@@ -87,7 +87,7 @@ export const PORestockConfirmModal = ({
   return (
     <>
       <section className="absolute bg-black/40 w-full h-full top-0 left-0 flex justify-center items-center z-50">
-        <div className="w-[820px] max-h-[90vh] overflow-y-auto bg-white px-10 py-8 rounded-lg border shadow-lg flex flex-col gap-4">
+        <div className="w-[1024px] max-h-[90vh] overflow-y-auto bg-white px-10 py-8 rounded-lg border shadow-lg flex flex-col gap-4">
           {/* Header */}
           <div>
             <div className="flex items-center gap-2">
@@ -168,10 +168,10 @@ export const PORestockConfirmModal = ({
                   </div>
                   <div
                     className={`col-span-1 text-right font-bold ${row.discrepancy > 0
-                        ? "text-blue-600"
-                        : row.discrepancy < 0
-                          ? "text-red-500"
-                          : "text-green-600"
+                      ? "text-blue-600"
+                      : row.discrepancy < 0
+                        ? "text-red-500"
+                        : "text-green-600"
                       }`}
                   >
                     {row.discrepancy > 0
@@ -200,7 +200,8 @@ export const PORestockConfirmModal = ({
           <details className="group border border-gray-200 rounded-md overflow-hidden bg-gray-50/50">
             <summary className="flex text-sm cursor-pointer items-center justify-between px-4 py-3 font-semibold text-gray-700 hover:bg-gray-100 list-none [&::-webkit-details-marker]:hidden">
               <span className="flex items-center gap-2">
-                Add restock notes
+                <ClipboardList className="w-4 h-4 text-gray-500" />
+                Add notes (optional)
               </span>
               <ChevronDown className="w-4 h-4 text-gray-500 transition-transform group-open:rotate-180" />
             </summary>

--- a/frontend/src/pages/admin/restock/po-restock/index.tsx
+++ b/frontend/src/pages/admin/restock/po-restock/index.tsx
@@ -5,7 +5,7 @@ import { PurchaseOrderRecord } from "@/features/purchase-order/purchase-order.mo
 import { InventoryProductModel } from "@/features/inventory/models/inventory.model";
 import { RestockCard2 } from "../new-restock/_components/restock-card-copy";
 import { PORestockConfirmModal } from "./_components/po-restock-confirm.modal";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Truck } from "lucide-react";
 
 export type PORestockCardState = {
   lineItemId: number;
@@ -66,21 +66,21 @@ function buildFakeProduct(
     },
     unitPresets: li.preset_ID
       ? [
-          {
-            assigned_At: "",
+        {
+          assigned_At: "",
+          preset_ID: li.preset_ID,
+          product_Preset_ID: 0,
+          presetPricing: [],
+          preset: {
             preset_ID: li.preset_ID,
-            product_Preset_ID: 0,
-            presetPricing: [],
-            preset: {
-              preset_ID: li.preset_ID,
-              preset_Code: li.unit_Preset?.preset_Code ?? "",
-              main_Unit_ID: 0,
-              created_At: "",
-              updated_At: "",
-              presetLevels,
-            },
+            preset_Code: li.unit_Preset?.preset_Code ?? "",
+            main_Unit_ID: 0,
+            created_At: "",
+            updated_At: "",
+            presetLevels,
           },
-        ]
+        },
+      ]
       : [],
     isComplete: false,
     isFavorited: false,
@@ -158,22 +158,32 @@ const PORestockPage = () => {
       )}
 
       {/* Header */}
-      <div className="flex items-center gap-3 mb-6">
+      <div className="flex items-start gap-4 mb-6 pb-4 border-b border-gray-200">
         <div
           onClick={() => navigate("/admin/restock")}
-          className="text-sm text-gray-500 hover:text-gray-700 hover:underline flex gap-2 items-center cursor-pointer hover:bg-gray-100 rounded-lg p-2 transition-colors duration-200"
+          className="text-gray-500 hover:text-gray-700 flex items-center cursor-pointer hover:bg-gray-100 rounded-lg p-2 transition-colors duration-200"
         >
-          <ArrowLeft />
-          <label>Back</label>
+          <ArrowLeft className="w-5 h-5" />
         </div>
-        <h1 className="text-lg font-semibold">PO Restock</h1>
-        <span className="text-saltbox-gray text-sm tracking-wider">
-          #{po.purchase_Order_Number}
-        </span>
-        <span className="text-xs text-gray-500">
-          {po.supplier.company_Name ||
-            `${po.supplier.first_Name} ${po.supplier.last_Name}`}
-        </span>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold text-gray-800">PO Restock</h1>
+            <span className="text-gray-500 font-medium">
+              #{po.purchase_Order_Number}
+            </span>
+            <span className="text-gray-400">•</span>
+            <span className="text-xs bg-yellow-50 text-yellow-600 px-3 py-0.5 rounded-full border border-yellow-200 font-medium">
+              Partial
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-gray-600 font-medium">
+            <Truck className="w-4 h-4" />
+            <span>
+              {po.supplier.company_Name ||
+                `${po.supplier.first_Name} ${po.supplier.last_Name}`}
+            </span>
+          </div>
+        </div>
       </div>
 
       {/* Cards grid */}
@@ -223,9 +233,9 @@ const PORestockPage = () => {
 
       {/* Footer action */}
       {activeCards.length > 0 && (
-        <div className="flex justify-end">
+        <div className="flex justify-end mt-4">
           <button
-            className="cursor-pointer text-white rounded text-sm"
+            className="cursor-pointer text-white bg-blue-500 hover:bg-blue-600 rounded px-6 py-2 text-sm font-medium"
             onClick={() => setIsConfirmOpen(true)}
           >
             Continue


### PR DESCRIPTION
- Add '#' symbol before PO Number in the page header
- Add "Partial" tag with yellow styling to the header
- Add Truck icon next to the supplier name and reposition it below the main heading
- Add a bottom line separator to the header section
- Style the "Continue" footer button with a blue background and position it at the bottom right corner
- Increase Restock Confirmation modal width to 1024px to prevent product name text wrapping
- Rename the restock notes label to "Add notes (optional)" and prepend a clipboard icon

<img width="1586" height="1010" alt="Screenshot_1" src="https://github.com/user-attachments/assets/10f972b2-1078-4e34-b593-a97ad4f03df5" />
